### PR TITLE
Update pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@ Only check steps which are required by your desired PR type.
 -->
 ### Add certificate
 - [ ] Added certificates are PEM encoded.
-- [ ] I renamed and moved added certificates using the [my_script.ps1](/noSpamProxy/smime-ca-bundle/blob/main/README.md) script.
+- [ ] I renamed and moved added certificates using the [RenameAndSortCertificates.ps1](/noSpamProxy/smime-ca-bundle/blob/main/RenameAndSortCertificates.ps1) script.
 
 ## Description
 


### PR DESCRIPTION
fixed wrong PS1 link

## What type of PR is this?

- [ ] Add certificate
- [ ] Remove certificate

## Checklist before requesting
<!--
Only check steps which are required by your desired PR type.
-->
### Add certificate
- [ ] Added certificates are PEM encoded.
- [ ] I renamed and moved added certificates using the [my_script.ps1](/noSpamProxy/smime-ca-bundle/blob/main/README.md) script.

## Description

<!--
Explain why you like to add/remove the desired certificate and provide a public accessible source if possible.
-->
The readme contains an old dummy link.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #
